### PR TITLE
Fix bss section to be cleard in Init_Machine function

### DIFF
--- a/i2c/Makefile
+++ b/i2c/Makefile
@@ -33,7 +33,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS) $(LIBGCC)
 	$(SIZE) $@

--- a/i2s/Makefile
+++ b/i2s/Makefile
@@ -36,7 +36,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS) $(LIBGCC)
 	$(SIZE) $@

--- a/led_blynk/Makefile
+++ b/led_blynk/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/mini-uart/Makefile
+++ b/mini-uart/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/pwm/Makefile
+++ b/pwm/Makefile
@@ -36,7 +36,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS) $(LIBGCC)
 	$(SIZE) $@

--- a/qemu-arm/Makefile
+++ b/qemu-arm/Makefile
@@ -25,7 +25,7 @@ OBJ = $(SRC_C:.c=.o) $(SRC_S:.s=.o)
 
 all: run
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/spi/Makefile
+++ b/spi/Makefile
@@ -33,7 +33,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS) $(LIBGCC)
 	$(SIZE) $@

--- a/timer-irq/Makefile
+++ b/timer-irq/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/timer-irq2/Makefile
+++ b/timer-irq2/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/video/Makefile
+++ b/video/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/video2/Makefile
+++ b/video2/Makefile
@@ -32,7 +32,7 @@ deploy: kernel.img
 #kernel.img: kernel.elf
 #	$(OBJCOPY) -O binary $< $@
 
-kernel.elf: $(OBJ) rpi.ld
+kernel.elf: $(OBJ)
 	$(ECHO) "LINK $@"
 	$(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
 	$(SIZE) $@


### PR DESCRIPTION
### Problem

It seems all linker labels have same address which is unexpected,
and it might cause problem,
especially bss section is not cleared in `Init_Machine` function.

I have tested in qemu-arm:

```sh
$ cd qemu-arm
$ make kernel.img
arm-none-eabi-gcc  -c main.c -o main.o
LINK kernel.elf
arm-none-eabi-ld -nostdlib -T rpi.ld -Map=kernel.elf.map --cref -o kernel.elf main.o rpi.ld 
arm-none-eabi-size kernel.elf
   text    data     bss     dec     hex filename
    580      24       4     608     260 kernel.elf
arm-none-eabi-objcopy -O binary kernel.elf kernel.img
$ arm-none-eabi-objdump -t kernel.elf | grep -E '__data|__rodata|__bss'
00010260 g       .bss	00000000 __rodata_end
00010260 g       .bss	00000000 __bss_end
00010260 g       .bss	00000000 __rodata_start
00010260 g       .bss	00000000 __data_end
00010260 g       .bss	00000000 __bss_start
00010260 g       .bss	00000000 __data_start
```

In the above log, size tells `bss` has 4 bytes length,
but `__bss_start` and `__bss_end` have same address(`00010260`), and other labels too.

In map file,

```sh
$ cat kernel.elf.map 
...

.rodata         0x0000000000010244       0x18
 *(.data*)
 .data          0x0000000000010244        0x0 main.o
 *(.data*)
 .rodata        0x0000000000010244       0x18 main.o
                0x000000000001025c                . = ALIGN (0x4)
                0x000000000001025c                __rodata_end = .
                0x000000000001025c                __data_start = .

.data
 *(.data*)
 *(.data*)

.igot.plt       0x000000000001025c        0x0
 .igot.plt      0x000000000001025c        0x0 main.o
                0x000000000001025c                . = ALIGN (0x4)
                0x000000000001025c                __data_end = .
                0x000000000001025c                __bss_start = .

.bss            0x000000000001025c        0x4
 *(.bss*)
 .bss           0x000000000001025c        0x0 main.o
 *(.bss*)
 COMMON         0x000000000001025c        0x4 main.o
                0x000000000001025c                uart0
                0x0000000000010260                . = ALIGN (0x4)
                0x0000000000010260                __bss_end = .
LOAD main.o
LOAD rpi.ld
                0x0000000000010260                __rodata_start = .
                0x0000000000010260                . = ALIGN (0x4)
                0x0000000000010260                __rodata_end = .
                0x0000000000010260                __data_start = .
                0x0000000000010260                . = ALIGN (0x4)
                0x0000000000010260                __data_end = .
                0x0000000000010260                __bss_start = .
                0x0000000000010260                . = ALIGN (0x4)
                0x0000000000010260                __bss_end = .
OUTPUT(kernel.elf elf32-littlearm)
...
```

labels defined in linker script appear twice.
I figured out that this is caused by Makefile:

```Makefile
kernel.elf: $(OBJ) rpi.ld
        ...
        $(LD) $(LDFLAGS) -o $@ $^ $(LIBS)
        ...
```

Makefile variable `$^` equals `$(OBJ) rpi.ld`,
so the command becomes

```sh
arm-none-eabi-ld -nostdlib -T rpi.ld -Map=kernel.elf.map --cref -o kernel.elf main.o rpi.ld 
```

`rpi.ld` are passed twice, I think this causes the problem.


### Solution

I think there are two ways to solve the problem:

  1. Use `$(OBJ)` instead of `$^`
  2. Remove `rpi.ld` from dependency to make `$^` object files only

I think `rpi.ld` is not changed often, so I prefer second solution.


### Result

Applying this change, labels have different address, and bss is cleared in `Init_Machine` function:

```sh
$ make kernel.img
arm-none-eabi-gcc  -c main.c -o main.o
LINK kernel.elf
arm-none-eabi-ld -nostdlib -T rpi.ld -Map=kernel.elf.map --cref -o kernel.elf main.o 
arm-none-eabi-size kernel.elf
   text	   data	    bss	    dec	    hex	filename
    580	     24	      4	    608	    260	kernel.elf
arm-none-eabi-objcopy -O binary kernel.elf kernel.img
$ arm-none-eabi-objdump -t kernel.elf | grep -E '__data|__rodata|__bss'
0001025c g       .bss	00000000 __rodata_end
00010260 g       .bss	00000000 __bss_end
00010244 g       .text	00000000 __rodata_start
0001025c g       .bss	00000000 __data_end
0001025c g       .bss	00000000 __bss_start
0001025c g       .bss	00000000 __data_start
$ cat kernel.elf.map 
...
.rodata         0x0000000000010244       0x18
 *(.data*)
 .data          0x0000000000010244        0x0 main.o
 .rodata        0x0000000000010244       0x18 main.o
                0x000000000001025c                . = ALIGN (0x4)
                0x000000000001025c                __rodata_end = .
                0x000000000001025c                __data_start = .

.data
 *(.data*)

.igot.plt       0x000000000001025c        0x0
 .igot.plt      0x000000000001025c        0x0 main.o
                0x000000000001025c                . = ALIGN (0x4)
                0x000000000001025c                __data_end = .
                0x000000000001025c                __bss_start = .

.bss            0x000000000001025c        0x4
 *(.bss*)
 .bss           0x000000000001025c        0x0 main.o
 COMMON         0x000000000001025c        0x4 main.o
                0x000000000001025c                uart0
                0x0000000000010260                . = ALIGN (0x4)
                0x0000000000010260                __bss_end = .
LOAD main.o
OUTPUT(kernel.elf elf32-littlearm)
...
```


### Note

Regardless of applying this change, it seems bss is filled with zero in elsewhere.
